### PR TITLE
Feature parser

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,7 +1,11 @@
 name: Check
 
-on: [push]
-
+# on: [push]
+on:
+  push:
+    branches:
+      - master
+      - develop
 
 env:
   CARGO_TERM_COLOR: always

--- a/src/TODO.md
+++ b/src/TODO.md
@@ -1,6 +1,7 @@
 # TODO
 
 - `ItemBranch`カンマ区切りの要素 -> `FuncElem` の`out_code_list`を消す
+  - `CommaParser`の構成も変更する必要がある
 
 - 予約後をまとめて定義する
 

--- a/src/TODO.md
+++ b/src/TODO.md
@@ -1,10 +1,6 @@
 # TODO
 
-- `ItemBranch`カンマ区切りの要素
-
-- `subscriptable` `callable`のマクロ設計
-
-- `subscriptable` `callable`のパーサー的な定義
+- `ItemBranch`カンマ区切りの要素 -> `FuncElem` の`out_code_list`を消す
 
 - 予約後をまとめて定義する
 

--- a/src/TODO.md
+++ b/src/TODO.md
@@ -1,7 +1,8 @@
 # TODO
 
-- `ItemBranch`カンマ区切りの要素 -> `FuncElem` の`out_code_list`を消す
-  - `CommaParser`の構成も変更する必要がある
+- `ItemBranch`カンマ区切りの要素 
+  - パース関連のコンパイラ開発者向けエラーの細分化
+
 
 - 予約後をまとめて定義する
 

--- a/src/abs/ast.rs
+++ b/src/abs/ast.rs
@@ -10,7 +10,7 @@ use crate::errors::parser_errors::ParserError;
 /// 抽象的なtoken
 /// プログラムの要素を表現できる
 #[derive(Clone, Debug)]
-pub enum BaseElem {
+pub enum ExprElem {
     BlockElem(BlockBranch),
     ListBlockElem(ListBlockBranch),
     ParenBlockElem(ParenBlockBranch),
@@ -25,7 +25,7 @@ pub enum BaseElem {
     UnKnownElem(UnKnownBranch),
 }
 
-impl BaseElem {
+impl ExprElem {
     pub fn show(&self) {
         match self {
             Self::BlockElem(e) => e.show(),
@@ -89,7 +89,7 @@ pub trait ASTBranch {
 /// ## resolve_self
 /// depthをインクリメントするときは、`resolve_self`内で宣言するParserにself.get_depth + 1をして実装する必要がある
 pub trait ASTAreaBranch {
-    fn new(contents: Option<Vec<BaseElem>>, depth: isize, loopdepth: isize) -> Self;
+    fn new(contents: Option<Vec<ExprElem>>, depth: isize, loopdepth: isize) -> Self;
 }
 
 pub trait RecursiveAnalysisElements {

--- a/src/abs/ast.rs
+++ b/src/abs/ast.rs
@@ -1,8 +1,15 @@
-use crate::token::{
-    block::BlockBranch, func::FuncBranch, list::ListBranch, list_block::ListBlockBranch,
-    operator::OperatorBranch, paren_block::ParenBlockBranch, string::StringBranch,
-    syntax::SyntaxBranch, syntax_box::SyntaxBoxBranch, unknown::UnKnownBranch, word::WordBranch,
-};
+use crate::token::block::BlockBranch;
+use crate::token::func::FuncBranch;
+use crate::token::item::ItemBranch;
+use crate::token::list::ListBranch;
+use crate::token::list_block::ListBlockBranch;
+use crate::token::operator::OperatorBranch;
+use crate::token::paren_block::ParenBlockBranch;
+use crate::token::string::StringBranch;
+use crate::token::syntax::SyntaxBranch;
+use crate::token::syntax_box::SyntaxBoxBranch;
+use crate::token::unknown::UnKnownBranch;
+use crate::token::word::WordBranch;
 
 use crate::errors::parser_errors::ParserError;
 
@@ -18,6 +25,7 @@ pub enum ExprElem {
     SyntaxBoxElem(SyntaxBoxBranch),
     FuncElem(FuncBranch),
     ListElem(ListBranch),
+    ItemElem(ItemBranch),
     // without ASTAreaBranch trait structures
     StringElem(StringBranch),
     WordElem(WordBranch),
@@ -37,6 +45,7 @@ impl ExprElem {
             Self::SyntaxElem(e) => e.show(),
             Self::SyntaxBoxElem(e) => e.show(),
             Self::FuncElem(e) => e.show(),
+            Self::ItemElem(e) => e.show(),
             Self::OpeElem(e) => e.show(),
             Self::ListElem(e) => e.show(),
         }
@@ -53,10 +62,12 @@ impl ExprElem {
             Self::SyntaxElem(e) => e.get_show_as_string(),
             Self::SyntaxBoxElem(e) => e.get_show_as_string(),
             Self::FuncElem(e) => e.get_show_as_string(),
+            Self::ItemElem(e) => e.get_show_as_string(),
             Self::OpeElem(e) => e.get_show_as_string(),
             Self::ListElem(e) => e.get_show_as_string(),
         }
     }
+
     pub fn resolve_self(&mut self) -> Result<(), ParserError> {
         match self {
             // recursive analysis elements
@@ -67,6 +78,7 @@ impl ExprElem {
             Self::SyntaxBoxElem(e) => e.resolve_self(),
             Self::FuncElem(e) => e.resolve_self(),
             Self::ListElem(e) => e.resolve_self(),
+            Self::ItemElem(e) => e.resolve_self(),
 
             // unrecursive analysis elements
             Self::StringElem(_) => Ok(()),

--- a/src/abs/ast.rs
+++ b/src/abs/ast.rs
@@ -26,7 +26,7 @@ pub enum ExprElem {
     FuncElem(FuncBranch),
     ListElem(ListBranch),
     ItemElem(ItemBranch),
-    // without ASTAreaBranch trait structures
+    // without RecursiveAnalysisElements trait structures
     StringElem(StringBranch),
     WordElem(WordBranch),
     OpeElem(OperatorBranch),

--- a/src/errors/parser_errors.rs
+++ b/src/errors/parser_errors.rs
@@ -1,8 +1,10 @@
+#[derive(Debug)]
 pub enum ParserError {
     QuotationNotClosed,
     BraceNotClosed,
     GroupingSyntaxBoxError, // please write \"if\",\"while\" or \"for\" statement head
     OperationError,         // OperationError 見つからない場合
     // for developers
+    DevError,
     Uncategorized,
 }

--- a/src/errors/parser_errors.rs
+++ b/src/errors/parser_errors.rs
@@ -1,6 +1,7 @@
 #[derive(Debug)]
 pub enum ParserError {
     QuotationNotClosed,
+    BraceNotOpened,
     BraceNotClosed,
     GroupingSyntaxBoxError, // please write \"if\",\"while\" or \"for\" statement head
     OperationError,         // OperationError 見つからない場合

--- a/src/parser/comma_parser.rs
+++ b/src/parser/comma_parser.rs
@@ -1,5 +1,5 @@
 use crate::abs::ast::ASTAreaBranch;
-use crate::abs::ast::BaseElem;
+use crate::abs::ast::ExprElem;
 
 use crate::errors::parser_errors::ParserError;
 use crate::parser::core_parser::Parser;
@@ -8,8 +8,8 @@ use crate::token::string::StringBranch;
 
 pub struct CommaParser {
     pub code: String,
-    pub code_list: Vec<BaseElem>,
-    pub out_code_list: Vec<Vec<BaseElem>>,
+    pub code_list: Vec<ExprElem>,
+    pub out_code_list: Vec<Vec<ExprElem>>,
     pub depth: isize,
     pub loopdepth: isize,
 }
@@ -21,17 +21,17 @@ impl CommaParser {
         self.grouping_quotation()?;
         // grouping_elements
         self.grouping_elements(
-            BaseElem::BlockElem,
+            ExprElem::BlockElem,
             Self::BLOCK_BRACE_OPEN,  // {
             Self::BLOCK_BRACE_CLOSE, // }
         )?;
         self.grouping_elements(
-            BaseElem::ListBlockElem,
+            ExprElem::ListBlockElem,
             Self::BLOCK_LIST_OPEN,  // [
             Self::BLOCK_LIST_CLOSE, // ]
         )?;
         self.grouping_elements(
-            BaseElem::ParenBlockElem,
+            ExprElem::ParenBlockElem,
             Self::BLOCK_PAREN_OPEN,  // (
             Self::BLOCK_PAREN_CLOSE, // )
         )?;
@@ -40,9 +40,9 @@ impl CommaParser {
     }
 
     fn grouping_args(&mut self) -> Result<(), ParserError> {
-        let mut group: Vec<BaseElem> = vec![];
+        let mut group: Vec<ExprElem> = vec![];
         for inner in &self.code_list {
-            if let BaseElem::UnKnownElem(v) = inner {
+            if let ExprElem::UnKnownElem(v) = inner {
                 if v.contents == Self::COMMA {
                     self.out_code_list.push(group.clone());
                     group.clear();
@@ -65,7 +65,7 @@ impl CommaParser {
         let mut group = String::new();
 
         for inner in &self.code_list {
-            if let BaseElem::UnKnownElem(ref v) = inner {
+            if let ExprElem::UnKnownElem(ref v) = inner {
                 if escape_flag {
                     group.push(v.contents);
                     escape_flag = false
@@ -74,7 +74,7 @@ impl CommaParser {
                 {
                     if open_flag {
                         group.push(v.contents);
-                        rlist.push(BaseElem::StringElem(StringBranch {
+                        rlist.push(ExprElem::StringElem(StringBranch {
                             contents: group.clone(),
                             depth: self.depth,
                         }));
@@ -103,19 +103,19 @@ impl CommaParser {
 
     fn grouping_elements<T>(
         &mut self,
-        elemtype: fn(T) -> BaseElem,
+        elemtype: fn(T) -> ExprElem,
         open_char: char,
         close_char: char,
     ) -> Result<(), ParserError>
     where
         T: ASTAreaBranch,
     {
-        let mut rlist: Vec<BaseElem> = Vec::new();
-        let mut group: Vec<BaseElem> = Vec::new();
+        let mut rlist: Vec<ExprElem> = Vec::new();
+        let mut group: Vec<ExprElem> = Vec::new();
         let mut depth: isize = 0;
 
         for inner in &self.code_list {
-            if let BaseElem::UnKnownElem(ref b) = inner {
+            if let ExprElem::UnKnownElem(ref b) = inner {
                 if b.contents == open_char {
                     match depth {
                         0 => { /*pass*/ }
@@ -161,7 +161,7 @@ impl CommaParser {
 }
 
 impl Parser<'_> for CommaParser {
-    fn create_parser_from_vec(code_list: Vec<BaseElem>, depth: isize, loopdepth: isize) -> Self {
+    fn create_parser_from_vec(code_list: Vec<ExprElem>, depth: isize, loopdepth: isize) -> Self {
         Self {
             code: String::new(),
             code_list,
@@ -181,7 +181,7 @@ impl Parser<'_> for CommaParser {
         }
     }
 
-    fn code2_vec_pre_proc_func(&self, code: &str) -> Vec<BaseElem> {
+    fn code2_vec_pre_proc_func(&self, code: &str) -> Vec<ExprElem> {
         todo!()
     }
 

--- a/src/parser/comma_parser.rs
+++ b/src/parser/comma_parser.rs
@@ -190,10 +190,6 @@ impl Parser<'_> for CommaParser {
         }
     }
 
-    fn code2_vec_pre_proc_func(&self, code: &str) -> Vec<ExprElem> {
-        todo!()
-    }
-
     fn resolve(&mut self) -> Result<(), ParserError> {
         self.code2vec()?;
         Ok(())

--- a/src/parser/core_parser.rs
+++ b/src/parser/core_parser.rs
@@ -151,12 +151,12 @@ pub trait Parser<'a> {
 
     fn new(code: String, depth: isize, loopdepth: isize) -> Self;
     fn resolve(&mut self) -> Result<(), ParserError>;
-    fn create_parser_from_vec(code_list: Vec<BaseElem>, depth: isize, loopdepth: isize) -> Self;
+    fn create_parser_from_vec(code_list: Vec<ExprElem>, depth: isize, loopdepth: isize) -> Self;
 
-    fn code2_vec_pre_proc_func(&self, code: &str) -> Vec<BaseElem> {
+    fn code2_vec_pre_proc_func(&self, code: &str) -> Vec<ExprElem> {
         return code
             .chars()
-            .map(|c| BaseElem::UnKnownElem(UnKnownBranch { contents: c }))
+            .map(|c| ExprElem::UnKnownElem(UnKnownBranch { contents: c }))
             .collect();
     }
 }

--- a/src/parser/expr_parser.rs
+++ b/src/parser/expr_parser.rs
@@ -22,6 +22,35 @@ pub struct ExprParser {
 }
 
 impl ExprParser {
+    pub fn code2vec(&mut self) -> Result<(), ParserError> {
+        // --- macro ---
+        self.grouping_quotation()?;
+        // grouping_elements
+        self.grouping_elements(
+            BaseElem::BlockElem,
+            Self::BLOCK_BRACE_OPEN,  // {
+            Self::BLOCK_BRACE_CLOSE, // }
+        )?;
+        self.grouping_elements(
+            BaseElem::ListBlockElem,
+            Self::BLOCK_LIST_OPEN,  // [
+            Self::BLOCK_LIST_CLOSE, // ]
+        )?;
+        self.grouping_elements(
+            BaseElem::ParenBlockElem,
+            Self::BLOCK_PAREN_OPEN,  // (
+            Self::BLOCK_PAREN_CLOSE, // )
+        )?;
+        // end of grouping_elements
+        self.grouping_words()?;
+        while self.contain_subscriptable() {
+            self.grouping_subscription()?;
+        }
+        self.grouoping_operator()?;
+        self.resolve_operation()?;
+        Ok(())
+    }
+
     fn grouping_words(&mut self) -> Result<(), ParserError> {
         // macro
         macro_rules! add_rlist {
@@ -178,35 +207,6 @@ impl ExprParser {
             return Err(ParserError::BraceNotClosed);
         }
         self.code_list = rlist;
-        Ok(())
-    }
-
-    pub fn code2vec(&mut self) -> Result<(), ParserError> {
-        // --- macro ---
-        self.grouping_quotation()?;
-        // grouping_elements
-        self.grouping_elements(
-            BaseElem::BlockElem,
-            Self::BLOCK_BRACE_OPEN,  // {
-            Self::BLOCK_BRACE_CLOSE, // }
-        )?;
-        self.grouping_elements(
-            BaseElem::ListBlockElem,
-            Self::BLOCK_LIST_OPEN,  // [
-            Self::BLOCK_LIST_CLOSE, // ]
-        )?;
-        self.grouping_elements(
-            BaseElem::ParenBlockElem,
-            Self::BLOCK_PAREN_OPEN,  // (
-            Self::BLOCK_PAREN_CLOSE, // )
-        )?;
-        // end of grouping_elements
-        self.grouping_words()?;
-        while self.contain_subscriptable() {
-            self.grouping_subscription()?;
-        }
-        self.grouoping_operator()?;
-        self.resolve_operation()?;
         Ok(())
     }
 

--- a/src/parser/expr_parser.rs
+++ b/src/parser/expr_parser.rs
@@ -8,7 +8,6 @@ use crate::token::func::FuncBranch;
 use crate::token::item::ItemBranch;
 use crate::token::list::ListBranch;
 use crate::token::operator::OperatorBranch;
-use crate::token::paren_block::ParenBlockBranch;
 use crate::token::string::StringBranch;
 use crate::token::syntax::SyntaxBranch;
 use crate::token::syntax_box::SyntaxBoxBranch;
@@ -454,11 +453,12 @@ impl ExprParser {
                 }
                 // [] ()
                 ExprElem::ListBlockElem(v) => {
+                    let list_items = ExprElem::ListBlockElem(v.clone());
                     if let Some(ExprElem::WordElem(ref wd)) = name_tmp {
                         if !Self::CONTROL_STATEMENT.contains(&wd.contents.as_str()) {
                             rlist.push(ExprElem::ListElem(ListBranch {
                                 name: Box::new(ExprElem::WordElem(wd.clone())),
-                                contents: v.clone(),
+                                contents: vec![list_items],
                                 depth: self.depth,
                                 loopdepth: self.loopdepth,
                             }));
@@ -472,14 +472,14 @@ impl ExprParser {
                     } else if let Some(ExprElem::FuncElem(ref fb)) = name_tmp {
                         rlist.push(ExprElem::ListElem(ListBranch {
                             name: Box::new(ExprElem::FuncElem(fb.clone())),
-                            contents: v.clone(),
+                            contents: vec![list_items],
                             depth: self.depth,
                             loopdepth: self.loopdepth,
                         }));
                     } else if let Some(ExprElem::ListElem(ref lb)) = name_tmp {
                         rlist.push(ExprElem::ListElem(ListBranch {
                             name: Box::new(ExprElem::ListElem(lb.clone())),
-                            contents: v.clone(),
+                            contents: vec![list_items],
                             depth: self.depth,
                             loopdepth: self.loopdepth,
                         }));
@@ -613,11 +613,6 @@ impl ExprParser {
                         depth: self.depth,
                         loopdepth: self.loopdepth,
                     });
-                    // let function_args = ExprElem::ParenBlockElem(ParenBlockBranch {
-                    //     contents: vec![arg1, arg2],
-                    //     depth: 0,
-                    //     loopdepth: 0,
-                    // });
                     self.code_list = vec![ExprElem::FuncElem(FuncBranch {
                         name: Box::new(name.clone()),
                         contents: vec![arg1, arg2],

--- a/src/parser/expr_parser.rs
+++ b/src/parser/expr_parser.rs
@@ -171,7 +171,7 @@ impl ExprParser {
                     match depth {
                         0 => { /*pass*/ }
                         1.. => group.push(inner.clone()),
-                        _ => return Err(ParserError::Uncategorized),
+                        _ => return Err(ParserError::BraceNotOpened),
                     }
                     depth += 1;
                 } else if b.contents == close_char {
@@ -186,13 +186,13 @@ impl ExprParser {
                             group.clear();
                         }
                         1.. => group.push(inner.clone()),
-                        _ => return Err(ParserError::Uncategorized),
+                        _ => return Err(ParserError::BraceNotOpened),
                     }
                 } else {
                     match depth {
                         0 => rlist.push(inner.clone()),
                         1.. => group.push(inner.clone()),
-                        _ => return Err(ParserError::Uncategorized),
+                        _ => return Err(ParserError::BraceNotOpened),
                     }
                 }
             } else {

--- a/src/parser/stmt_parser.rs
+++ b/src/parser/stmt_parser.rs
@@ -6,7 +6,7 @@ use crate::token::word::WordBranch;
 
 pub struct StmtParser {
     pub code: String,
-    pub code_list: Vec<BaseElem>,
+    pub code_list: Vec<ExprElem>,
     pub depth: isize,
     pub loopdepth: isize,
 }
@@ -19,7 +19,7 @@ impl StmtParser {
         let mut group = String::new();
 
         for inner in &self.code_list {
-            if let BaseElem::UnKnownElem(ref v) = inner {
+            if let ExprElem::UnKnownElem(ref v) = inner {
                 if escape_flag {
                     group.push(v.contents);
                     escape_flag = false
@@ -29,7 +29,7 @@ impl StmtParser {
                 {
                     if open_flag {
                         group.push(v.contents);
-                        rlist.push(BaseElem::StringElem(StringBranch {
+                        rlist.push(ExprElem::StringElem(StringBranch {
                             contents: group.clone(),
                             depth: self.depth,
                         }));
@@ -58,19 +58,19 @@ impl StmtParser {
 
     fn grouping_elements<T>(
         &mut self,
-        elemtype: fn(T) -> BaseElem,
+        elemtype: fn(T) -> ExprElem,
         open_char: char,
         close_char: char,
     ) -> Result<(), ParserError>
     where
         T: ASTAreaBranch,
     {
-        let mut rlist: Vec<BaseElem> = Vec::new();
-        let mut group: Vec<BaseElem> = Vec::new();
+        let mut rlist: Vec<ExprElem> = Vec::new();
+        let mut group: Vec<ExprElem> = Vec::new();
         let mut depth: isize = 0;
 
         for inner in &self.code_list {
-            if let BaseElem::UnKnownElem(ref b) = inner {
+            if let ExprElem::UnKnownElem(ref b) = inner {
                 if b.contents == open_char {
                     match depth {
                         0 => {}
@@ -115,16 +115,16 @@ impl StmtParser {
     }
 
     fn grouping_words(&mut self) -> Result<(), ParserError> {
-        let mut rlist: Vec<BaseElem> = Vec::new();
+        let mut rlist: Vec<ExprElem> = Vec::new();
         let mut group: String = String::new();
 
         for inner in &self.code_list {
-            if let BaseElem::UnKnownElem(ref e) = inner {
+            if let ExprElem::UnKnownElem(ref e) = inner {
                 if Self::SPLIT_CHAR.contains(&e.contents)
                 // inner in split
                 {
                     if !group.is_empty() {
-                        rlist.push(BaseElem::WordElem(WordBranch {
+                        rlist.push(ExprElem::WordElem(WordBranch {
                             contents: group.clone(),
                             depth: self.depth,
                             loopdepth: self.loopdepth,
@@ -135,7 +135,7 @@ impl StmtParser {
                 // inner in split
                 {
                     if !group.is_empty() {
-                        rlist.push(BaseElem::WordElem(WordBranch {
+                        rlist.push(ExprElem::WordElem(WordBranch {
                             contents: group.clone(),
                             depth: self.depth,
                             loopdepth: self.loopdepth,
@@ -148,7 +148,7 @@ impl StmtParser {
                 }
             } else {
                 if !group.is_empty() {
-                    rlist.push(BaseElem::WordElem(WordBranch {
+                    rlist.push(ExprElem::WordElem(WordBranch {
                         contents: group.clone(),
                         depth: self.depth,
                         loopdepth: self.loopdepth,
@@ -159,7 +159,7 @@ impl StmtParser {
             }
         }
         if !group.is_empty() {
-            rlist.push(BaseElem::WordElem(WordBranch {
+            rlist.push(ExprElem::WordElem(WordBranch {
                 contents: group.clone(),
                 depth: self.depth,
                 loopdepth: self.loopdepth,
@@ -174,17 +174,17 @@ impl StmtParser {
         self.grouping_quotation()?;
         self.grouping_words()?;
         self.grouping_elements(
-            BaseElem::BlockElem,
+            ExprElem::BlockElem,
             Self::BLOCK_BRACE_OPEN,  // {
             Self::BLOCK_BRACE_CLOSE, // }
         )?;
         self.grouping_elements(
-            BaseElem::ListBlockElem,
+            ExprElem::ListBlockElem,
             Self::BLOCK_LIST_OPEN,  // [
             Self::BLOCK_LIST_CLOSE, // ]
         )?;
         self.grouping_elements(
-            BaseElem::ParenBlockElem,
+            ExprElem::ParenBlockElem,
             Self::BLOCK_PAREN_OPEN,  // (
             Self::BLOCK_PAREN_CLOSE, // )
         )?;
@@ -202,7 +202,7 @@ impl Parser<'_> for StmtParser {
         }
     }
 
-    fn create_parser_from_vec(code_list: Vec<BaseElem>, depth: isize, loopdepth: isize) -> Self {
+    fn create_parser_from_vec(code_list: Vec<ExprElem>, depth: isize, loopdepth: isize) -> Self {
         Self {
             code: String::new(),
             code_list,

--- a/src/token/README.md
+++ b/src/token/README.md
@@ -1,8 +1,8 @@
 # token modules
 
-- recursion parse token (that implement ASTAreaBranch)
+- recursion parse token (that implement RecursiveAnalysisElements)
 
-each module has "resolve_self" method and it parse itself inner contents 
+  each module has `resolve_self` method and it parse itself inner contents 
 
   - block
 
@@ -15,3 +15,16 @@ each module has "resolve_self" method and it parse itself inner contents
   - syntax_box
 
   - syntax
+
+# Rule of `ExprElem`
+
+after parsing, there are two possible states of `Vec<ExprElem>`
+
+- length of `Vec<ExprElem>` 1
+
+  this is the case that `ExprElem` is pure expression, or only item of the list that has a one element
+
+- length of `Vec<ExprElem>` 1 <
+  
+  `ExprElem` is item of list, or args of function 
+  

--- a/src/token/block.rs
+++ b/src/token/block.rs
@@ -10,7 +10,7 @@ use crate::parser::stmt_parser::*;
 ///
 #[derive(Clone, Debug)]
 pub struct BlockBranch {
-    pub contents: Option<Vec<BaseElem>>,
+    pub contents: Option<Vec<ExprElem>>,
     pub depth: isize,
     pub loopdepth: isize,
 }
@@ -41,7 +41,7 @@ impl RecursiveAnalysisElements for BlockBranch {
 }
 
 impl ASTAreaBranch for BlockBranch {
-    fn new(contents: Option<Vec<BaseElem>>, depth: isize, loopdepth: isize) -> Self {
+    fn new(contents: Option<Vec<ExprElem>>, depth: isize, loopdepth: isize) -> Self {
         Self {
             contents,
             depth,

--- a/src/token/decvalue.rs
+++ b/src/token/decvalue.rs
@@ -1,7 +1,7 @@
 use crate::abs::ast::ExprElem;
 
 #[derive(Clone, Debug)]
-struct DecValueBranch {
+pub struct DecValueBranch {
     pub valuename: String, // TODO:ここはいずれ、パターンにしたい
     pub contents: Vec<ExprElem>,
     pub depth: isize,

--- a/src/token/decvalue.rs
+++ b/src/token/decvalue.rs
@@ -1,9 +1,9 @@
-use crate::abs::ast::BaseElem;
+use crate::abs::ast::ExprElem;
 
 #[derive(Clone, Debug)]
 struct DecValueBranch {
     pub valuename: String, // TODO:ここはいずれ、パターンにしたい
-    pub contents: Vec<BaseElem>,
+    pub contents: Vec<ExprElem>,
     pub depth: isize,
     pub loopdepth: isize,
     // flags

--- a/src/token/func.rs
+++ b/src/token/func.rs
@@ -1,8 +1,8 @@
 use crate::abs::ast::*;
 use crate::errors::parser_errors::ParserError;
+
 use crate::parser::comma_parser::CommaParser;
 use crate::parser::core_parser::Parser;
-use crate::parser::expr_parser::ExprParser;
 
 use super::paren_block::ParenBlockBranch;
 
@@ -65,23 +65,26 @@ impl RecursiveAnalysisElements for FuncBranch {
         // 引数の解決
         if self.contents.is_empty() {
             // このresolve_self methodが走る時点で長さが1でなければ不正
-            return Err(ParserError::Uncategorized);
+            return Err(ParserError::DevError);
         }
         let first_elem = &self.contents[0];
 
         if let ExprElem::OpeElem(_) = &*self.name {
-            //pass
+            // 演算子だった場合はpass
         } else if let ExprElem::ParenBlockElem(ParenBlockBranch {
             contents: v,
             depth,
             loopdepth,
         }) = first_elem
         {
+            if 1 < self.contents.len() {
+                return Err(ParserError::DevError);
+            }
             let mut c_parser = CommaParser::create_parser_from_vec(v.to_vec(), *depth, *loopdepth);
             c_parser.resolve()?;
             self.contents = c_parser.code_list;
         } else {
-            return Err(ParserError::Uncategorized);
+            return Err(ParserError::DevError);
         }
         for inner in &mut self.contents {
             inner.resolve_self()?;

--- a/src/token/func.rs
+++ b/src/token/func.rs
@@ -10,9 +10,9 @@ use super::paren_block::ParenBlockBranch;
 /// 関数呼び出しのトークン
 #[derive(Clone, Debug)]
 pub struct FuncBranch {
-    pub name: Box<BaseElem>,
+    pub name: Box<ExprElem>,
     pub contents: ParenBlockBranch,
-    pub out_code_list: Vec<Vec<BaseElem>>, // args
+    pub out_code_list: Vec<Vec<ExprElem>>, // args
     pub depth: isize,
     pub loopdepth: isize,
 }
@@ -70,7 +70,7 @@ impl RecursiveAnalysisElements for FuncBranch {
         } = self.contents.clone()
         {
             let mut comma_parser = CommaParser::create_parser_from_vec(v, depth, loopdepth);
-            if let BaseElem::OpeElem(_) = &*self.name {
+            if let ExprElem::OpeElem(_) = &*self.name {
                 // もし、関数の名前が演算子だった場合、 `self.out_code_list`に対しては処理をしない
                 // pass
             } else {

--- a/src/token/func.rs
+++ b/src/token/func.rs
@@ -21,12 +21,6 @@ impl ASTBranch for FuncBranch {
         println!("{}func name", " ".repeat(self.depth as usize * 4));
         self.name.show();
         println!("{}(", " ".repeat(self.depth as usize * 4));
-        // for (i, j) in self.out_code_list.iter().enumerate() {
-        //     println!("{}arg{}", " ".repeat(self.depth as usize * 4), i);
-        //     for k in j {
-        //         k.show();
-        //     }
-        // }
         for i in &self.contents {
             i.show();
         }

--- a/src/token/func.rs
+++ b/src/token/func.rs
@@ -35,14 +35,13 @@ impl ASTBranch for FuncBranch {
         );
         let paren_open = format!("{}(\n", " ".repeat(self.depth as usize * 4));
         let mut args_group = String::new();
-        for (i, j) in self.contents.iter().enumerate() {
+        for j in &self.contents {
             args_group = format!(
-                "{}{}arg{}\n",
-                args_group,
+                "{}{}{}\n",
                 " ".repeat(self.depth as usize * 4),
-                i
+                args_group,
+                j.get_show_as_string()
             );
-            args_group = format!("{}{}\n", args_group, j.get_show_as_string());
         }
         let paren_close = format!("{})", " ".repeat(self.depth as usize * 4));
         format!(

--- a/src/token/item.rs
+++ b/src/token/item.rs
@@ -14,16 +14,19 @@ pub struct ItemBranch {
 
 impl ASTBranch for ItemBranch {
     fn show(&self) {
+        println!("{}Item(", " ".repeat(self.depth as usize * 4));
         for i in &self.contents {
             i.show();
         }
+        println!("{})", " ".repeat(self.depth as usize * 4));
     }
 
     fn get_show_as_string(&self) -> String {
-        let mut rstr = String::new();
+        let mut rstr = format!("{}Item(", " ".repeat(self.depth as usize * 4));
         for i in &self.contents {
             rstr = format!("{}{}", rstr, i.get_show_as_string());
         }
+        rstr = format!("{}\n{})", rstr, " ".repeat(self.depth as usize * 4));
         rstr
     }
 }

--- a/src/token/item.rs
+++ b/src/token/item.rs
@@ -1,0 +1,48 @@
+use crate::abs::ast::ASTBranch;
+use crate::abs::ast::ExprElem;
+use crate::abs::ast::RecursiveAnalysisElements;
+use crate::errors::parser_errors::ParserError;
+use crate::parser::core_parser::Parser;
+use crate::parser::expr_parser::ExprParser;
+
+#[derive(Clone, Debug)]
+pub struct ItemBranch {
+    pub contents: Vec<ExprElem>,
+    pub depth: isize,
+    pub loopdepth: isize,
+}
+
+impl ASTBranch for ItemBranch {
+    fn show(&self) {
+        for i in &self.contents {
+            i.show();
+        }
+    }
+
+    fn get_show_as_string(&self) -> String {
+        let mut rstr = String::new();
+        for i in &self.contents {
+            rstr = format!("{}{}", rstr, i.get_show_as_string());
+        }
+        rstr
+    }
+}
+
+impl RecursiveAnalysisElements for ItemBranch {
+    fn resolve_self(&mut self) -> Result<(), ParserError> {
+        // 式パーサーによって解析
+        let mut parser =
+            ExprParser::create_parser_from_vec(self.contents.clone(), self.depth, self.loopdepth);
+        match parser.code2vec() {
+            Ok(_) => {
+                let mut rlist = parser.code_list;
+                for i in &mut rlist {
+                    i.resolve_self()?
+                }
+                self.contents = rlist;
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
+    }
+}

--- a/src/token/item.rs
+++ b/src/token/item.rs
@@ -22,7 +22,7 @@ impl ASTBranch for ItemBranch {
     }
 
     fn get_show_as_string(&self) -> String {
-        let mut rstr = format!("{}Item(", " ".repeat(self.depth as usize * 4));
+        let mut rstr = format!("{}Item(\n", " ".repeat(self.depth as usize * 4));
         for i in &self.contents {
             rstr = format!("{}{}", rstr, i.get_show_as_string());
         }

--- a/src/token/list.rs
+++ b/src/token/list.rs
@@ -9,7 +9,7 @@ use super::paren_block::ParenBlockBranch;
 
 #[derive(Clone, Debug)]
 pub struct ListBranch {
-    pub name: Box<BaseElem>,
+    pub name: Box<ExprElem>,
     pub contents: ListBlockBranch,
     pub depth: isize,
     pub loopdepth: isize,

--- a/src/token/list.rs
+++ b/src/token/list.rs
@@ -1,16 +1,15 @@
 use crate::abs::ast::*;
 
 use crate::errors::parser_errors::ParserError;
+use crate::parser::comma_parser::CommaParser;
 use crate::parser::core_parser::Parser;
-use crate::parser::expr_parser::ExprParser;
 
-use super::list_block::ListBlockBranch;
-use super::paren_block::ParenBlockBranch;
+use crate::token::list_block::ListBlockBranch;
 
 #[derive(Clone, Debug)]
 pub struct ListBranch {
     pub name: Box<ExprElem>,
-    pub contents: ListBlockBranch,
+    pub contents: Vec<ExprElem>,
     pub depth: isize,
     pub loopdepth: isize,
 }
@@ -20,7 +19,9 @@ impl ASTBranch for ListBranch {
         println!("{}List name", " ".repeat(self.depth as usize * 4));
         self.name.show();
         println!("{}(", " ".repeat(self.depth as usize * 4));
-        self.contents.show();
+        for i in &self.contents {
+            i.show();
+        }
         println!("{})", " ".repeat(self.depth as usize * 4));
     }
 
@@ -31,14 +32,15 @@ impl ASTBranch for ListBranch {
             self.name.get_show_as_string()
         );
         let paren_open = format!("{}(\n", " ".repeat(self.depth as usize * 4));
+        let mut list_items = String::new();
+        for i in &self.contents {
+            list_items = format!("{}{}", list_items, i.get_show_as_string());
+        }
         let paren_close = format!("{})\n", " ".repeat(self.depth as usize * 4));
 
         format!(
             "{}{}{}{}",
-            paren_open,
-            function_name_section,
-            self.contents.get_show_as_string(),
-            paren_close,
+            paren_open, function_name_section, list_items, paren_close,
         )
     }
 }
@@ -46,8 +48,27 @@ impl ASTBranch for ListBranch {
 impl RecursiveAnalysisElements for ListBranch {
     fn resolve_self(&mut self) -> Result<(), ParserError> {
         self.name.resolve_self()?;
-        // self.contents.resolve_self()?;
-        self.contents.resolve_self()?;
+
+        if self.contents.len() != 1 {
+            return Err(ParserError::DevError);
+        }
+        let first_elem = &self.contents[0];
+
+        if let ExprElem::ListBlockElem(ListBlockBranch {
+            contents: v,
+            depth,
+            loopdepth,
+        }) = first_elem
+        {
+            let mut c_parser = CommaParser::create_parser_from_vec(v.to_vec(), *depth, *loopdepth);
+            c_parser.resolve()?;
+            self.contents = c_parser.code_list;
+        } else {
+            return Err(ParserError::DevError);
+        }
+        for inner in &mut self.contents {
+            inner.resolve_self()?;
+        }
         Ok(())
     }
 }

--- a/src/token/list_block.rs
+++ b/src/token/list_block.rs
@@ -9,8 +9,8 @@ use crate::parser::expr_parser::ExprParser;
 /// 中では式を解析するパーサを呼び出す必要がある
 #[derive(Clone, Debug)]
 pub struct ListBlockBranch {
-    pub contents: Vec<BaseElem>,
-    pub out_code_list: Vec<Vec<BaseElem>>,
+    pub contents: Vec<ExprElem>,
+    pub out_code_list: Vec<Vec<ExprElem>>,
     pub depth: isize,
     pub loopdepth: isize,
 }
@@ -36,7 +36,7 @@ impl ASTBranch for ListBlockBranch {
 }
 
 impl ASTAreaBranch for ListBlockBranch {
-    fn new(contents: Option<Vec<BaseElem>>, depth: isize, loopdepth: isize) -> Self {
+    fn new(contents: Option<Vec<ExprElem>>, depth: isize, loopdepth: isize) -> Self {
         Self {
             contents: if let Some(s) = contents { s } else { vec![] },
             out_code_list: Vec::new(),

--- a/src/token/list_block.rs
+++ b/src/token/list_block.rs
@@ -10,7 +10,6 @@ use crate::parser::expr_parser::ExprParser;
 #[derive(Clone, Debug)]
 pub struct ListBlockBranch {
     pub contents: Vec<ExprElem>,
-    pub out_code_list: Vec<Vec<ExprElem>>,
     pub depth: isize,
     pub loopdepth: isize,
 }
@@ -39,7 +38,6 @@ impl ASTAreaBranch for ListBlockBranch {
     fn new(contents: Option<Vec<ExprElem>>, depth: isize, loopdepth: isize) -> Self {
         Self {
             contents: if let Some(s) = contents { s } else { vec![] },
-            out_code_list: Vec::new(),
             depth,
             loopdepth,
         }
@@ -52,14 +50,11 @@ impl RecursiveAnalysisElements for ListBlockBranch {
             CommaParser::create_parser_from_vec(self.contents.clone(), self.depth, self.loopdepth);
         c_parser.code2vec()?;
         c_parser.resolve()?;
-        self.out_code_list = c_parser.out_code_list;
-        for code_list in &mut self.out_code_list {
-            let mut e_parser =
-                ExprParser::create_parser_from_vec(code_list.clone(), self.depth, self.loopdepth);
-            e_parser.code2vec()?;
-            e_parser.resolve()?;
-            *code_list = e_parser.code_list;
-        }
+        let mut e_parser =
+            ExprParser::create_parser_from_vec(self.contents.clone(), self.depth, self.loopdepth);
+        e_parser.code2vec()?;
+        e_parser.resolve()?;
+        self.contents = e_parser.code_list;
         Ok(())
     }
 }

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -10,6 +10,8 @@ pub mod syntax_box;
 
 pub mod decvalue;
 
+pub mod item;
+
 // structures without ASTAreaBranch trait b
 pub mod string;
 pub mod unknown;

--- a/src/token/paren_block.rs
+++ b/src/token/paren_block.rs
@@ -13,7 +13,7 @@ use crate::parser::expr_parser::ExprParser;
 /// 実装する
 #[derive(Clone, Debug)]
 pub struct ParenBlockBranch {
-    pub contents: Option<Vec<BaseElem>>,
+    pub contents: Option<Vec<ExprElem>>,
     pub depth: isize,
     pub loopdepth: isize,
 }
@@ -67,7 +67,7 @@ impl ASTBranch for ParenBlockBranch {
 }
 
 impl ASTAreaBranch for ParenBlockBranch {
-    fn new(contents: Option<Vec<BaseElem>>, depth: isize, loopdepth: isize) -> Self {
+    fn new(contents: Option<Vec<ExprElem>>, depth: isize, loopdepth: isize) -> Self {
         Self {
             contents,
             depth,

--- a/src/token/syntax.rs
+++ b/src/token/syntax.rs
@@ -21,6 +21,7 @@ impl ASTBranch for SyntaxBranch {
     fn show(&self) {
         todo!()
     }
+
     fn get_show_as_string(&self) -> String {
         todo!()
     }

--- a/src/token/syntax_box.rs
+++ b/src/token/syntax_box.rs
@@ -16,6 +16,7 @@ impl ASTBranch for SyntaxBoxBranch {
     fn show(&self) {
         todo!()
     }
+
     fn get_show_as_string(&self) -> String {
         todo!()
     }

--- a/src/token/unknown.rs
+++ b/src/token/unknown.rs
@@ -11,6 +11,7 @@ impl ASTBranch for UnKnownBranch {
     fn show(&self) {
         println!("UnKnownBranch :\"{}\"", self.contents);
     }
+
     fn get_show_as_string(&self) -> String {
         format!("UnKnownBranch :\"{}\"", self.contents)
     }

--- a/tests/README.md
+++ b/tests/README.md
@@ -63,3 +63,13 @@ expr_parserが正常に動作するかを確かめるテスト01
 ```bash
 cargo test --package lichen-lang --test lib -- tests::unit_test01 --exact --show-output
 ```
+
+## テストの走るタイミング
+
+テストはローカル環境で上のコマンドで実行することができる。
+
+developまたは,masterブランチへPRを送ったとき。また、それぞれにマージされたとき以下のテストが実行される。
+
+```bash
+cargo test
+```

--- a/tests/README.md
+++ b/tests/README.md
@@ -11,7 +11,7 @@
 ### expr test 00
 `test case`
 ```
-(10 + 1) + 2 * x
+ !a&& !b
 ```
 
 ```bash

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -176,6 +176,7 @@ mod tests {
             let string_code: String = String::from(code);
             let mut e_parser = ExprParser::new(string_code, 0, 0);
 
+            println!("------------------------------------------");
             println!("test case -> {}", code);
             if e_parser.resolve().is_err() {
                 println!("ParseError occured");

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -189,6 +189,5 @@ mod tests {
                 }
             }
         }
-        // let code = "tarai(1)(2)(3)";
     }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -167,7 +167,9 @@ mod tests {
     #[test]
     fn unit_test01() {
         let test_cases = vec![
+            "a+1*2",
             "tarai[1][2][3]",
+            "f(1,2,g(1,2,3))",
             "tarai(1)(2)(3)",
             "tarai(1)[2](3)",
             "tarai[1](2)[3]",
@@ -178,12 +180,12 @@ mod tests {
 
             println!("------------------------------------------");
             println!("test case -> {}", code);
-            if e_parser.resolve().is_err() {
-                println!("ParseError occured");
-            } else {
-                // println!("{:#?}", e_parser.code_list);
-                for i in e_parser.code_list {
-                    i.show();
+            match e_parser.resolve() {
+                Err(e) => println!("{:?}", e),
+                Ok(_) => {
+                    for i in e_parser.code_list {
+                        i.show();
+                    }
                 }
             }
         }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -9,37 +9,6 @@ mod tests {
     use lichen_lang::parser::core_parser::Parser;
     use lichen_lang::parser::expr_parser::ExprParser;
 
-    #[test]
-    fn test00() {
-        println!("{}hello{}", " ".repeat(4), "@".repeat(4));
-    }
-
-    fn func00() -> Result<i32, i32> {
-        Err(42)
-    }
-
-    fn func01() -> Result<i32, i32> {
-        Err(func00()?)
-    }
-
-    #[test]
-    fn test01() {
-        let a = func01();
-        match a {
-            Ok(a) => println!("OK {}", a),
-            Err(e) => println!("ERR {}", e),
-        }
-    }
-
-    #[test]
-    fn test02() {
-        let mut a = vec![0, 1, 2];
-        let b = vec![3, 4, 5];
-
-        a.extend(b);
-        println!("{:?}", a);
-    }
-
     // expr tests
 
     #[test]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -117,7 +117,7 @@ mod tests {
             vec!["a", "+", "b", "+", "c"],   // a+b+c
             vec!["(", "a", "+", "bc", ")", "+", "(", "cde", "-", "defg", ")"], // (a+bc)+(cde-defg)
             vec!["func", "(", "10", ",", "1", ")", "+", "2", "*", "x"], // func(10,1)+2*x
-            vec!["tarai", "(", "1", ")", "(", "2", ")", "(", "3", ")"], // func(10,1)+2*x
+            vec!["tarai", "(", "1", ")", "(", "2", ")", "(", "3", ")"], // tarai(1)(2)(3)
         ];
 
         for test_case in test_cases {
@@ -180,7 +180,7 @@ mod tests {
             if e_parser.resolve().is_err() {
                 println!("ParseError occured");
             } else {
-                println!("{:#?}", e_parser.code_list);
+                // println!("{:#?}", e_parser.code_list);
                 for i in e_parser.code_list {
                     i.show();
                 }


### PR DESCRIPTION
# 主な変更

- `BaseElem` -> `ExprElem`への構造体の名前の変更
- `ListBranch` `FuncBranch`構造体から、`out_code_list`セクションを取り除き`contents`の型を`Vec<ExprElem>`にした。
- `ItemBranch`という関数の引数やリストのアイテムを格納するトークンを追加